### PR TITLE
修复校验必填项方法的一处bug

### DIFF
--- a/src/Core/Utility/Validate/Func.php
+++ b/src/Core/Utility/Validate/Func.php
@@ -262,7 +262,7 @@ class Func
     }
 
     static function REQUIRED($data,array $rawData,$args):bool {
-        return $data === null ? false : true;
+        return empty($data) ? false : true;
     }
 
     static function SAME($data,array $rawData,$args):bool


### PR DESCRIPTION
必填的校验方法有问题，当$data = ''; 时，返回的结果是true,实际想要的是false。处