### PR TITLE
去除重复 commnand initialize 重复调用

### DIFF
--- a/src/Command/DefaultCommand/Reload.php
+++ b/src/Command/DefaultCommand/Reload.php
@@ -33,7 +33,6 @@ class Reload implements CommandInterface
         if(in_array('produce',$args)){
             Core::getInstance()->setIsDev(false);
         }
-        Core::getInstance()->initialize();
         $Conf = Config::getInstance();
         $res = '';
         $pidFile = $Conf->getConf("MAIN_SERVER.SETTING.pid_file");

--- a/src/Command/DefaultCommand/Stop.php
+++ b/src/Command/DefaultCommand/Stop.php
@@ -33,7 +33,6 @@ class Stop implements CommandInterface
         if(in_array('produce',$args)){
             Core::getInstance()->setIsDev(false);
         }
-        Core::getInstance()->initialize();
         $Conf = Config::getInstance();
         $pidFile = $Conf->getConf("MAIN_SERVER.SETTING.pid_file");
         if (file_exists($pidFile)) {


### PR DESCRIPTION
initialize 方法在 CommandRunner 中已经调用过了，在 initilize 中使用了 定义常量、引用方法等操作时会报错。