### PR TITLE
Make config hot-reload possible

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -79,7 +79,7 @@ class Config
     public function loadFile($filePath,bool $merge = true):bool
     {
         if (file_exists($filePath)) {
-            $confData = require_once $filePath;
+            $confData = include $filePath;
             if(is_array($confData)){
                 if($merge){
                     $this->conf->merge($confData);


### PR DESCRIPTION
使用 require_once 加载 php 格式的配置文件，会出现无法通过热重载重新读取的问题。改成 include 以解决此问题。由于 include 的客体是一个数组，不会出现重复引入出错的问题，这点不用担心。